### PR TITLE
Made changes, User friendlier, instructions and changing res in CLI of ODT

### DIFF
--- a/ODTKRA/Main.cpp
+++ b/ODTKRA/Main.cpp
@@ -5,6 +5,9 @@
 
 void killODT(int param)
 {
+	//Reverse ODT cli commands
+	system("echo service set-pixels-per-display-pixel-override 1 | \"C:\\Program Files\\Oculus\\Support\\oculus-diagnostics\\OculusDebugToolCLI.exe\"");
+
 	LPCWSTR Target_window_Name = L"Oculus Debug Tool";
 	HWND hWindowHandle = FindWindow(NULL, Target_window_Name);
 	if (hWindowHandle != NULL) {
@@ -79,9 +82,9 @@ int main()
 	signal(SIGBREAK, killODT);
 
 	//User friendly information
-	std::cout << "ODTKRA has started\n" << std::endl;
 	std::cout << "ODTKRA uses Oculus Debug Tool to keep your rift alive.\n It is basically a \"advanced macro\", \nwhich means you interacting with the debug tool can cause ODTKRA to fail. \n If ODTKRA stops working then close and reopen it." << std::endl;
 	std::cout << "The Oculus Debug Tool is supposed to be minimized, let it stay so." << std::endl;
+	std::cout << "\nThis program changes the resolution of the Rift CV1 to a very low amount, it will be reversed when program exits or when computer restarts." << std::endl;
 	std::cout << "\nLog:" << std::endl;
 
 	SYSTEMTIME st;

--- a/ODTKRA/Main.cpp
+++ b/ODTKRA/Main.cpp
@@ -1,5 +1,7 @@
+#include <iostream>
 #include <Windows.h>
 #include <csignal>
+#include <stdio.h>
 
 void killODT(int param)
 {
@@ -12,19 +14,8 @@ void killODT(int param)
 	Sleep(500);
 }
 
-int main()
+void start_ODT(HWND& hWindowHandle, LPCWSTR& Target_window_Name)
 {
-	LPCWSTR Target_window_Name = L"Oculus Debug Tool";
-	HWND hWindowHandle = FindWindow(NULL, Target_window_Name);
-
-	// Close ODT if it's already open because we have no idea what is currently selected
-	if (hWindowHandle != NULL) {
-		SendMessage(hWindowHandle, WM_CLOSE, 0, 0);
-		SwitchToThisWindow(hWindowHandle, true);
-	}
-
-	Sleep(500); // not sure if needed
-
 	// Starts ODT
 	ShellExecute(NULL, L"open", L"C:\\Program Files\\Oculus\\Support\\oculus-diagnostics\\OculusDebugTool.exe", NULL, NULL, SW_SHOWDEFAULT);
 	Sleep(1000); // not sure if needed
@@ -41,6 +32,40 @@ int main()
 	}
 
 	ShowWindow(hWindowHandle, SW_MINIMIZE);
+}
+
+void ODT_CLI()
+{
+	//Sets "set-pixels-per-display-pixel-override" to 0.0001 to decrease performance overhead
+	system("echo service set-pixels-per-display-pixel-override 0.0001 | \"C:\\Program Files\\Oculus\\Support\\oculus-diagnostics\\OculusDebugToolCLI.exe\"");
+
+	//Turn off ASW, we do not need it
+	system("echo server: asw.Off | \"C:\\Program Files\\Oculus\\Support\\oculus-diagnostics\\OculusDebugToolCLI.exe\"");
+
+	//Clear screen
+	system("cls");
+}
+
+int main()
+{
+
+	LPCWSTR Target_window_Name = L"Oculus Debug Tool";
+	HWND hWindowHandle = FindWindow(NULL, Target_window_Name);
+
+	// Close ODT if it's already open because we have no idea what is currently selected
+	if (hWindowHandle != NULL) {
+		SendMessage(hWindowHandle, WM_CLOSE, 0, 0);
+		SwitchToThisWindow(hWindowHandle, true);
+	}
+
+	Sleep(500); // not sure if needed
+
+	//Sends commands to the Oculus Debug Tool CLI to decrease performance overhead
+	//Unlikely to do much, but no reason not to.
+	ODT_CLI();
+
+	//Starts Oculus Debug Tool
+	start_ODT(hWindowHandle, Target_window_Name);
 
 	Sleep(1000);
 
@@ -52,6 +77,15 @@ int main()
 	signal(SIGABRT, killODT);
 	signal(SIGTERM, killODT);
 	signal(SIGBREAK, killODT);
+
+	//User friendly information
+	std::cout << "ODTKRA has started\n" << std::endl;
+	std::cout << "ODTKRA uses Oculus Debug Tool to keep your rift alive.\n It is basically a \"advanced macro\", \nwhich means you interacting with the debug tool can cause ODTKRA to fail. \n If ODTKRA stops working then close and reopen it." << std::endl;
+	std::cout << "The Oculus Debug Tool is supposed to be minimized, let it stay so." << std::endl;
+	std::cout << "\nLog:" << std::endl;
+
+	SYSTEMTIME st;
+
 	// Presses up arrow key and then down every 600 seconds
 	while (true) {
 		SendMessage(wxWindow, WM_KEYDOWN, VK_UP, 0);
@@ -60,6 +94,10 @@ int main()
 		SendMessage(wxWindow, WM_KEYDOWN, VK_DOWN, 0);
 		SendMessage(wxWindow, WM_KEYUP, VK_DOWN, 0);
 		Sleep(600000);
+
+		//Log keeping
+		GetSystemTime(&st);
+		std::cout << "Tracking refreshed at " << st.wHour << ":" << st.wMinute << std::endl;
 	}
 
 	return 0;

--- a/ODTKRA/ODTKRA.vcxproj
+++ b/ODTKRA/ODTKRA.vcxproj
@@ -29,26 +29,26 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/README.md
+++ b/README.md
@@ -2,3 +2,12 @@
 Uses the Oculus Debug Tool to keep your rift from going to sleep
 
 I made this to keep my rift from going to sleep while using mm0zct's Oculus_Touch_Steam_Link Driver
+
+Instructions:
+- Download the exe file in releases.
+
+- Run exe after starting Touch Link or Driver4VR (depending on what software you are running)
+
+- Let ODTKRA do its thing and do not touch the Oculus Debug tool, it is supposed to be minimized.
+
+- Your headset will now not go to sleep, if it does, restart ODTKRA.


### PR DESCRIPTION
First time I have ever made a pull request so we'll see if everything is correct.

Changes include more instructions, a log system which a user wanted and commands sent to the CLI version of ODT to hopefully lower overhead.

Did want to add a success or failure note to the log system, which would have been driven by asking the Oculus app if the headset was active, but I am not entirely sure I can, needs further testing. If I figure out a way then it can also be used to automatically restart the Oculus Debug tool in case of problem, either because of user error or the debug tool failing to connect, which it can do very rarely.